### PR TITLE
Update image pull from docker hub: leggedroboticsusp/locosim:jupyter-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This repository is a customized setup based on [locosim](https://github.com/mfoc
     ```bash
     git clone https://github.com/gbrlb/locosim_jupyter.git
     cd locosim_jupyter
-    ./prepare.sh
     ```
 
 ### Usage

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-CONTAINER_NAME=locosim_jupyter
-CONTAINER_TAG=0.1
+CONTAINER_NAME=leggedroboticsusp/locosim
+CONTAINER_TAG=jupyter-v0.2
 CONTAINER_IMAGE=$CONTAINER_NAME:$CONTAINER_TAG
 
 # Host paths
@@ -9,9 +9,13 @@ HOST_USER_HOME=$(pwd)/$USER
 HOST_WORKDIR=$HOST_USER_HOME/ros_ws/src
 HOST_LOCOSIMDIR=$HOST_WORKDIR/locosim
 
-# Container paths
-echo "Building $1 docker image..."
-docker build --no-cache -f Dockerfile -t $CONTAINER_IMAGE .
+if docker image inspect "$CONTAINER_IMAGE" >/dev/null 2>&1; then
+    echo "Image $CONTAINER_IMAGE found locally, skipping pull."
+else
+    echo "Pulling $CONTAINER_IMAGE docker image..."
+    docker pull $CONTAINER_IMAGE
+fi
+# docker build --no-cache -f Dockerfile -t $CONTAINER_IMAGE .
 
 # create HOST_WORKDIR
 mkdir -p "$HOST_WORKDIR"

--- a/run_linux.sh
+++ b/run_linux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+source ./prepare.sh
 # Allow local docker containers to connect to the X server
 xhost +local:docker
 
@@ -34,4 +34,4 @@ docker run --rm -it \
     --ulimit rtprio=98:98 \
     --name locosim_jupyter \
     --entrypoint bash \
-    locosim_jupyter:0.1
+    $CONTAINER_IMAGE

--- a/run_linux_gpu.sh
+++ b/run_linux_gpu.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ./prepare.sh
 xhost +local:docker
 
 docker run --rm -it \
@@ -24,4 +25,4 @@ docker run --rm -it \
     --ulimit rtprio=98:98 \
     --name locosim_jupyter \
     --entrypoint bash \
-    locosim_jupyter:0.1
+    $CONTAINER_IMAGE

--- a/run_wsl.sh
+++ b/run_wsl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+source ./prepare.sh
 # Allow Docker containers to access the WSLg/host X server
 xhost +SI:localuser:$(whoami)
 
@@ -29,4 +29,4 @@ docker run --rm -it \
     --ulimit rtprio=98:98 \
     --name locosim_jupyter \
     --entrypoint bash \
-    locosim_jupyter:0.1
+    $CONTAINER_IMAGE


### PR DESCRIPTION
Created a Docker image in the laboratory’s Docker Hub repository using the  [Dockerfile](https://github.com/leggedrobotics-usp/locosim_jupyter/blob/3dedcfa5ade540947d07d549ae2476b8636a949b/Dockerfile).
The image is available at: [leggedroboticsusp/locosim:jupyter-v0.2](https://hub.docker.com/layers/leggedroboticsusp/locosim/jupyter-v0.2/images/sha256-c79cf2d4c582b09e26cf3e7ecb6d7b5e3da9f23017c35199a7e5c741c2b78a50)

This change makes the image reference static and avoids potential issues from future updates to external sources.
